### PR TITLE
Feature/priority boot sequence

### DIFF
--- a/app/src/interfaces/ServiceInterface.ts
+++ b/app/src/interfaces/ServiceInterface.ts
@@ -2,6 +2,11 @@ import {Container} from 'inversify';
 
 export default interface ServiceInterface {
     /**
+     * @type {number} the priority for the boot method, lower numbers should be executed earlier
+     */
+    bootPriority: number;
+
+    /**
      * Run when booting the application
      *
      * @param {Container} container

--- a/app/src/interfaces/ServiceInterface.ts
+++ b/app/src/interfaces/ServiceInterface.ts
@@ -4,7 +4,7 @@ export default interface ServiceInterface {
     /**
      * @type {number} the priority for the boot method, lower numbers should be executed earlier
      */
-    bootPriority: number;
+    readonly bootPriority: number;
 
     /**
      * Run when booting the application

--- a/app/src/services/census/CensusStreamService.ts
+++ b/app/src/services/census/CensusStreamService.ts
@@ -11,6 +11,8 @@ import Census from '../../config/census';
 
 @injectable()
 export default class CensusStreamService implements ServiceInterface {
+    public readonly bootPriority = 10;
+
     private static readonly logger = getLogger('ps2census');
 
     private readonly wsClient: Client;

--- a/app/src/services/mongo/MongoDatabaseConnectionService.ts
+++ b/app/src/services/mongo/MongoDatabaseConnectionService.ts
@@ -5,6 +5,8 @@ import MongoDBConnection from './MongoDBConnection';
 
 @injectable()
 export default class MongoDatabaseConnectionService implements ServiceInterface {
+    public readonly bootPriority = 10;
+
     private static readonly logger = getLogger('MongoDatabaseConnectionService');
 
     private readonly dbClient: MongoDBConnection;

--- a/app/src/services/subscribers/CensusEventSubscriberService.ts
+++ b/app/src/services/subscribers/CensusEventSubscriberService.ts
@@ -80,13 +80,14 @@ export default class CensusEventSubscriberService implements ServiceInterface {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     public async boot(): Promise<void> {
-        CensusEventSubscriberService.logger.info('Booting EventListenerService... (NOT IMPLEMENTED)');
+        CensusEventSubscriberService.logger.info('Booting EventListenerService...');
+
+        this.constructListeners();
     }
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     public async start(): Promise<void> {
-        CensusEventSubscriberService.logger.info('Starting EventListenerService...');
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        void await this.constructListeners();
+        CensusEventSubscriberService.logger.info('Starting EventListenerService... (NOT IMPLEMENTED)');
     }
 
     public terminate(): void {

--- a/app/src/services/subscribers/CensusEventSubscriberService.ts
+++ b/app/src/services/subscribers/CensusEventSubscriberService.ts
@@ -24,6 +24,8 @@ import FacilityControlEvent from '../../handlers/census/events/FacilityControlEv
 
 @injectable()
 export default class CensusEventSubscriberService implements ServiceInterface {
+    public readonly bootPriority = 10;
+
     private static readonly logger = getLogger('EventListenerService');
 
     private readonly wsClient: Client;


### PR DESCRIPTION
Allows for a more granular boot process. Same code can also be used for terminating the app(e.g. database closing after event stream). For the start process this is not necessary as there is the boot process for that.