### PR TITLE
#80 - TEMP AF fix for Census dropouts until upstream handles it

### DIFF
--- a/app/src/services/census/CensusStreamService.ts
+++ b/app/src/services/census/CensusStreamService.ts
@@ -3,7 +3,7 @@
 import ServiceInterface from '../../interfaces/ServiceInterface';
 import {getLogger} from '../../logger';
 import {inject, injectable} from 'inversify';
-import {Client, MetagameEvent, PS2Event, Events} from 'ps2census';
+import {Client, MetagameEvent, PS2Event} from 'ps2census';
 import {getUnixTimestamp} from '../../utils/time';
 import {World} from '../../constants/world';
 import {MetagameEventIds} from '../../constants/metagameEventIds';

--- a/app/src/services/census/CensusStreamService.ts
+++ b/app/src/services/census/CensusStreamService.ts
@@ -80,8 +80,7 @@ export default class CensusStreamService implements ServiceInterface {
             CensusStreamService.logger.warn(`Census stream duplicate detected: ${event.event_name}`);
         });
 
-        this.wsClient.on('ps2Event', (event: PS2Event) => {
-            console.log(event);
+        this.wsClient.on('ps2Event', () => {
             this.lastMessage = new Date();
         });
 


### PR DESCRIPTION
Currently we are loosing connections and not getting metagame events. This PR adds a simple check to re-connect the census stream should we not get any messages.