### PR TITLE
Bump ps2census v0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,9 +1912,9 @@
       }
     },
     "ps2census": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ps2census/-/ps2census-0.3.9.tgz",
-      "integrity": "sha512-ziIdCawUWYIwZBoFXvy20XsiRzRzXm0igUOeUR+efp/DOvMgu/960PEww0G8QFjXR3Fp7UBpFx+6F5vQCIEteA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ps2census/-/ps2census-0.4.2.tgz",
+      "integrity": "sha512-vaQky2P1syLEOFTpfKG09U2Ngateu9buZ8+XJdI8/60KmuPa35k4BSKQEFX8giPyiHjldfewRfbgD376LWKhWg==",
       "requires": {
         "axios": "^0.19.2",
         "bufferutil": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "logform": "^2.2.0",
     "mongoose": "^5.9.24",
     "mysql2": "^2.1.0",
-    "ps2census": "^0.3.9",
+    "ps2census": "^0.4.2",
     "reflect-metadata": "^0.1.13",
     "sqlite3": "^4.2.0",
     "usage": "^0.7.1",

--- a/src/handlers/aggregate/global/GlobalClassAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalClassAggregate.ts
@@ -6,6 +6,7 @@ import {TYPES} from '../../../constants/types';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import AggregateHandlerInterface from '../../../interfaces/AggregateHandlerInterface';
 import {GlobalClassAggregateSchemaInterface} from '../../../models/aggregate/global/GlobalClassAggregateModel';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class GlobalClassAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -39,15 +40,15 @@ export default class GlobalClassAggregate implements AggregateHandlerInterface<D
         // Victim deaths always counted in every case
         victimDocs.push({$inc: {deaths: 1}});
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             attackerDocs.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             attackerDocs.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // Attacker and victim are the same here, so it doesn't matter which
             victimDocs.push({$inc: {suicides: 1}});
         }

--- a/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
@@ -6,7 +6,7 @@ import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
 import {
     GlobalFactionCombatAggregateSchemaInterface,
-    GlobalFactionCombatAggregateSubSchemaInterface
+    GlobalFactionCombatAggregateSubSchemaInterface,
 } from '../../../models/aggregate/global/GlobalFactionCombatAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import FactionUtils from '../../../utils/FactionUtils';

--- a/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
@@ -4,9 +4,13 @@ import {getLogger} from '../../../logger';
 import {inject, injectable} from 'inversify';
 import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
-import {GlobalFactionCombatAggregateSchemaInterface, GlobalFactionCombatAggregateSubSchemaInterface} from '../../../models/aggregate/global/GlobalFactionCombatAggregateModel';
+import {
+    GlobalFactionCombatAggregateSchemaInterface,
+    GlobalFactionCombatAggregateSubSchemaInterface
+} from '../../../models/aggregate/global/GlobalFactionCombatAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import FactionUtils from '../../../utils/FactionUtils';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class GlobalFactionCombatAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -31,7 +35,7 @@ export default class GlobalFactionCombatAggregate implements AggregateHandlerInt
         const documents = [];
 
         // Increment attacker faction kills
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const attackerKillKey = `${FactionUtils.parseFactionIdToShortName(event.attackerFaction)}.kills`;
             documents.push(
@@ -47,7 +51,7 @@ export default class GlobalFactionCombatAggregate implements AggregateHandlerInt
             {$inc: {['totals.deaths']: 1}},
         );
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const teamKillKey = `${FactionUtils.parseFactionIdToShortName(event.attackerFaction)}.teamKills`;
             documents.push(
@@ -56,7 +60,7 @@ export default class GlobalFactionCombatAggregate implements AggregateHandlerInt
             );
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const suicideKey = `${FactionUtils.parseFactionIdToShortName(event.characterFaction)}.suicides`;
             documents.push(

--- a/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalFactionCombatAggregate.ts
@@ -4,10 +4,7 @@ import {getLogger} from '../../../logger';
 import {inject, injectable} from 'inversify';
 import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
-import {
-    GlobalFactionCombatAggregateSchemaInterface,
-    GlobalFactionCombatAggregateSubSchemaInterface,
-} from '../../../models/aggregate/global/GlobalFactionCombatAggregateModel';
+import {GlobalFactionCombatAggregateSchemaInterface, GlobalFactionCombatAggregateSubSchemaInterface} from '../../../models/aggregate/global/GlobalFactionCombatAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import FactionUtils from '../../../utils/FactionUtils';
 import {Kill} from 'ps2census/dist/client/events/Death';

--- a/src/handlers/aggregate/global/GlobalPlayerAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalPlayerAggregate.ts
@@ -6,6 +6,7 @@ import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
 import {GlobalPlayerAggregateSchemaInterface} from '../../../models/aggregate/global/GlobalPlayerAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class GlobalPlayerAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -38,15 +39,15 @@ export default class GlobalPlayerAggregate implements AggregateHandlerInterface<
         // Victim deaths always counted in every case
         victimDocs.push({$inc: {deaths: 1}});
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             attackerDocs.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             attackerDocs.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // Attacker and victim are the same here, so it doesn't matter which
             victimDocs.push({$inc: {suicides: 1}});
         }

--- a/src/handlers/aggregate/global/GlobalWeaponAggregate.ts
+++ b/src/handlers/aggregate/global/GlobalWeaponAggregate.ts
@@ -6,6 +6,7 @@ import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import {GlobalWeaponAggregateSchemaInterface} from '../../../models/aggregate/global/GlobalWeaponAggregateModel';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class GlobalWeaponAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -30,15 +31,15 @@ export default class GlobalWeaponAggregate implements AggregateHandlerInterface<
 
         const documents = [];
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             documents.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             documents.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             documents.push({$inc: {suicides: 1}});
         }
 

--- a/src/handlers/aggregate/instance/InstanceClassAggregate.ts
+++ b/src/handlers/aggregate/instance/InstanceClassAggregate.ts
@@ -6,6 +6,7 @@ import {TYPES} from '../../../constants/types';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import AggregateHandlerInterface from '../../../interfaces/AggregateHandlerInterface';
 import {InstanceClassAggregateSchemaInterface} from '../../../models/aggregate/instance/InstanceClassAggregateModel';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class InstanceClassAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -39,15 +40,15 @@ export default class InstanceClassAggregate implements AggregateHandlerInterface
         // Victim deaths always counted in every case
         victimDocs.push({$inc: {deaths: 1}});
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             attackerDocs.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             attackerDocs.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // Attacker and victim are the same here, so it doesn't matter which
             victimDocs.push({$inc: {suicides: 1}});
         }

--- a/src/handlers/aggregate/instance/InstanceFactionCombatAggregate.ts
+++ b/src/handlers/aggregate/instance/InstanceFactionCombatAggregate.ts
@@ -7,6 +7,7 @@ import {TYPES} from '../../../constants/types';
 import {InstanceFactionCombatAggregateSchemaInterface, InstanceFactionCombatAggregateSubSchemaInterface} from '../../../models/aggregate/instance/InstanceFactionCombatAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import FactionUtils from '../../../utils/FactionUtils';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class InstanceFactionCombatAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -31,7 +32,7 @@ export default class InstanceFactionCombatAggregate implements AggregateHandlerI
         const documents = [];
 
         // Increment attacker faction kills
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const attackerKillKey = `${FactionUtils.parseFactionIdToShortName(event.attackerFaction)}.kills`;
             documents.push(
@@ -47,7 +48,7 @@ export default class InstanceFactionCombatAggregate implements AggregateHandlerI
             {$inc: {['totals.deaths']: 1}},
         );
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const teamKillKey = `${FactionUtils.parseFactionIdToShortName(event.attackerFaction)}.teamKills`;
             documents.push(
@@ -56,7 +57,7 @@ export default class InstanceFactionCombatAggregate implements AggregateHandlerI
             );
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/restrict-template-expressions
             const suicideKey = `${FactionUtils.parseFactionIdToShortName(event.characterFaction)}.suicides`;
             documents.push(

--- a/src/handlers/aggregate/instance/InstancePlayerAggregate.ts
+++ b/src/handlers/aggregate/instance/InstancePlayerAggregate.ts
@@ -6,6 +6,7 @@ import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
 import {InstancePlayerAggregateSchemaInterface} from '../../../models/aggregate/instance/InstancePlayerAggregateModel';
 import ApplicationException from '../../../exceptions/ApplicationException';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class InstancePlayerAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -39,15 +40,15 @@ export default class InstancePlayerAggregate implements AggregateHandlerInterfac
         // Victim deaths always counted in every case
         victimDocs.push({$inc: {deaths: 1}});
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             attackerDocs.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             attackerDocs.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             // Attacker and victim are the same here, so it doesn't matter which
             victimDocs.push({$inc: {suicides: 1}});
         }

--- a/src/handlers/aggregate/instance/InstanceWeaponAggregate.ts
+++ b/src/handlers/aggregate/instance/InstanceWeaponAggregate.ts
@@ -6,6 +6,7 @@ import MongooseModelFactory from '../../../factories/MongooseModelFactory';
 import {TYPES} from '../../../constants/types';
 import ApplicationException from '../../../exceptions/ApplicationException';
 import {InstanceWeaponAggregateSchemaInterface} from '../../../models/aggregate/instance/InstanceWeaponAggregateModel';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class InstanceWeaponAggregate implements AggregateHandlerInterface<DeathEvent> {
@@ -30,15 +31,15 @@ export default class InstanceWeaponAggregate implements AggregateHandlerInterfac
 
         const documents = [];
 
-        if (!event.isTeamkill && !event.isSuicide) {
+        if (event.killType === Kill.Normal) {
             documents.push({$inc: {kills: 1}});
         }
 
-        if (event.isTeamkill) {
+        if (event.killType === Kill.TeamKill) {
             documents.push({$inc: {teamKills: 1}});
         }
 
-        if (event.isSuicide) {
+        if (event.killType === Kill.Suicide) {
             documents.push({$inc: {suicides: 1}});
         }
 

--- a/src/handlers/census/DeathEventHandler.ts
+++ b/src/handlers/census/DeathEventHandler.ts
@@ -8,6 +8,7 @@ import CharacterPresenceHandlerInterface from '../../interfaces/CharacterPresenc
 import ApplicationException from '../../exceptions/ApplicationException';
 import {InstanceDeathSchemaInterface} from '../../models/instance/InstanceDeathModel';
 import MongooseModelFactory from '../../factories/MongooseModelFactory';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class DeathEventHandler implements EventHandlerInterface<DeathEvent> {
@@ -59,23 +60,23 @@ export default class DeathEventHandler implements EventHandlerInterface<DeathEve
         return true;
     }
 
-    private async storeEvent(deathEvent: DeathEvent): Promise<boolean> {
+    private async storeEvent(event: DeathEvent): Promise<boolean> {
         try {
             await this.factory.model.create({
-                instance: deathEvent.instance.instanceId,
-                attacker: deathEvent.attackerCharacterId,
-                player: deathEvent.characterId,
-                timestamp: deathEvent.timestamp,
-                attackerFiremode: deathEvent.attackerFiremodeId,
-                attackerLoadout: deathEvent.attackerLoadoutId,
-                attackerFaction: deathEvent.attackerFaction,
-                weapon: deathEvent.attackerWeaponId,
-                playerLoadout: deathEvent.characterLoadoutId,
-                playerFaction: deathEvent.characterFaction,
-                isHeadshot: deathEvent.isHeadshot,
-                isSuicide: deathEvent.isSuicide,
-                isTeamkill: deathEvent.isTeamkill,
-                vehicle: deathEvent.attackerVehicleId,
+                instance: event.instance.instanceId,
+                attacker: event.attackerCharacterId,
+                player: event.characterId,
+                timestamp: event.timestamp,
+                attackerFiremode: event.attackerFiremodeId,
+                attackerLoadout: event.attackerLoadoutId,
+                attackerFaction: event.attackerFaction,
+                weapon: event.attackerWeaponId,
+                playerLoadout: event.characterLoadoutId,
+                playerFaction: event.characterFaction,
+                isHeadshot: event.isHeadshot,
+                isSuicide: event.killType === Kill.Suicide,
+                isTeamkill: event.killType === Kill.TeamKill,
+                vehicle: event.attackerVehicleId,
             });
             return true;
         } catch (err) {

--- a/src/handlers/census/events/DeathEvent.ts
+++ b/src/handlers/census/events/DeathEvent.ts
@@ -26,6 +26,7 @@ import {Death} from 'ps2census';
 import PS2AlertsInstanceInterface from '../../../interfaces/PS2AlertsInstanceInterface';
 import {Faction} from '../../../constants/faction';
 import FactionUtils from '../../../utils/FactionUtils';
+import {Kill} from 'ps2census/dist/client/events/Death';
 
 @injectable()
 export default class DeathEvent {
@@ -57,9 +58,7 @@ export default class DeathEvent {
 
     public readonly isHeadshot: boolean;
 
-    public readonly isSuicide: boolean;
-
-    public readonly isTeamkill: boolean;
+    public readonly killType: Kill;
 
     constructor(event: Death, instance: PS2AlertsInstanceInterface) {
         this.instance = instance;
@@ -116,10 +115,6 @@ export default class DeathEvent {
 
         this.isHeadshot = event.is_headshot;
 
-        // Additional logic to figure out things Census doesn't tell us...
-        this.isSuicide = this.characterId === this.attackerCharacterId;
-
-        // TK logic, does NOT include NSO. If same faction but not same character
-        this.isTeamkill = this.attackerFaction === this.characterFaction && !this.isSuicide;
+        this.killType = event.kill_type;
     }
 }


### PR DESCRIPTION
Closes #117, #106, #114.

Before this gets merged. Some things that I want to ask:
- First errors in the handlers will now crash the application as a result of a change in the ps2census lib. Should we let it just crash or do we want to add a helper to catch the errors?;
- Shall I include a redis cache according to the specs of the ps2census contract?;
- ~~Should I add a timeout to the kernel on termination(so that discord is able to log)?~~